### PR TITLE
build: reduce docker cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 7
+      default-days: 1
     commit-message:
       prefix: "feat" # alpine updates are always features
 


### PR DESCRIPTION
Following [Homebrew's](https://docs.brew.sh/Supply-Chain-Security) approach, prioritize Alpine updates, which are more trustworthy